### PR TITLE
Explore sample data and add shape tests

### DIFF
--- a/data_samples/OBSERVATIONS.md
+++ b/data_samples/OBSERVATIONS.md
@@ -1,0 +1,22 @@
+# Data Sample Observations
+
+## Background Health Metrics
+- Seven JSON files dated 2025-08-18 through 2025-08-24.
+- Nine metric names observed: `apple_exercise_time`, `heart_rate`, `heart_rate_variability`, `resting_heart_rate`, `running_speed`, `sleep_analysis`, `swimming_distance`, `walking_heart_rate_average`, `walking_running_distance`.
+- Entries include numeric `qty`, `source`, and timestamps such as `date`, `start`/`end`, or `startDate`/`endDate`.
+- Overall timestamp range: 2025-08-17 23:07:33+01:00 to 2025-08-24 19:27:18+01:00.
+
+## Workout Data
+- One JSON file containing four workouts.
+- Each workout has an `id`, `start` and `end` times, and arrays like `heartRateData`, `activeEnergy`, and `walkingAndRunningDistance`.
+- Heart rate sample counts per workout: 128, 93, 76, and 47.
+- Timestamps follow the `%Y-%m-%d %H:%M:%S %z` format.
+
+## Common Fields
+- Most samples include `qty`, `units`, and `source` fields.
+- Timestamps may appear under `date`, `start`, `end`, `startDate`, or `endDate`.
+
+## Reading & Validation Tips
+- Load files with Python's `json` module and iterate over `data["metrics"]` or `data["workouts"]`.
+- Ensure each sample has a `qty` and at least one timestamp field.
+- Parse timestamps using `datetime.strptime(value, "%Y-%m-%d %H:%M:%S %z")`.

--- a/tests/test_samples_shape.py
+++ b/tests/test_samples_shape.py
@@ -1,0 +1,31 @@
+import glob
+import json
+
+
+def test_background_metrics_structure():
+    for path in glob.glob("data_samples/Background Health Metrics/*.json"):
+        with open(path) as f:
+            payload = json.load(f)
+        assert "data" in payload and "metrics" in payload["data"]
+        metrics = payload["data"]["metrics"]
+        assert metrics, path
+        for metric in metrics:
+            assert {"name", "units", "data"} <= metric.keys()
+            for sample in metric["data"]:
+                assert any(
+                    key in sample for key in ("qty", "Avg", "value")
+                )
+                assert any(
+                    key in sample for key in ("date", "start", "startDate")
+                )
+
+
+def test_workout_data_structure():
+    path = "data_samples/Workout Data/HealthAutoExport-2025-34.json"
+    with open(path) as f:
+        payload = json.load(f)
+    workouts = payload["data"]["workouts"]
+    assert len(workouts) == 4
+    for workout in workouts:
+        assert "id" in workout
+        assert workout.get("heartRateData"), workout["id"]


### PR DESCRIPTION
## Summary
- document observations on background health metrics and workout samples
- add tests ensuring sample JSON structures contain expected fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6833c9648325af8f43d3ca09a0dc